### PR TITLE
Refactorings to reduce overhead / simplify

### DIFF
--- a/app/http/router.js
+++ b/app/http/router.js
@@ -9,7 +9,7 @@ const protector = require('./protector')
 const redirector = require('./redirector')
 const auth = require('../auth')
 
-const handle = (error, res) => {
+const handle = res => error => {
   if (error === 'NOT_FOUND') {
     res.status(404).send({
       message: 'Error: resource not found',
@@ -40,9 +40,7 @@ module.exports = (server, credentials, shortlinks) => {
       res.status(data.status_code)
       .header('Location', data.url)
       .send(data)
-    }).catch((error) => {
-      handle(error, res)
-    })
+    }).catch(handle(res))
   })
 
   server.put('/:token', protector(admin), validator(request.shortlink), (req, res) => {
@@ -58,7 +56,7 @@ module.exports = (server, credentials, shortlinks) => {
           code: 405
         })
       } else {
-        handle(error, res)
+        handle(res)(error)
       }
     })
   })
@@ -72,9 +70,7 @@ module.exports = (server, credentials, shortlinks) => {
     shortlinks.create(token, req.body.url, req.body.status_code)
     .then((shortlink) => {
       res.status(201).send(shortlink)
-    }).catch((error) => {
-      handle(error, res)
-    })
+    }).catch(handle(res))
   })
 
   server.post('/:token', protector(admin), validator(request.shortlink), (req, res) => {
@@ -88,17 +84,13 @@ module.exports = (server, credentials, shortlinks) => {
     }
     shortlinks.update(token, data).then((shortlink) => {
       res.status(200).send(shortlink)
-    }).catch((error) => {
-      handle(error, res)
-    })
+    }).catch(handle(res))
   })
 
   server.delete('/:token', protector(admin), (req, res) => {
     const token = trimSlashes(req.params.token)
     shortlinks.delete(token).then((shortlink) => {
       res.status(200).send(shortlink)
-    }).catch((error) => {
-      handle(error, res)
-    })
+    }).catch(handle(res))
   })
 }

--- a/app/http/router.js
+++ b/app/http/router.js
@@ -45,13 +45,6 @@ module.exports = (server, credentials, shortlinks) => {
     })
   })
 
-  server.put('/', protector(admin), (_, res) => {
-    res.status(405).header('Allow', 'GET, POST').send({
-      message: 'Error - PUT is not allowed on the base route',
-      code: 405
-    })
-  })
-
   server.put('/:token', protector(admin), validator(request.shortlink), (req, res) => {
     const token = trimSlashes(req.params.token)
 

--- a/app/odm.js
+++ b/app/odm.js
@@ -15,69 +15,47 @@ module.exports = (collection) => {
       updated: now
     })
 
-    return new Promise((resolve, reject) => {
-      collection.insertOne(doc).then((doc) => {
-        resolve(schema.output(doc.ops[0]))
-      }).catch((error) => {
+    return collection
+      .insertOne(doc)
+      .then((doc) => schema.output(doc.ops[0]))
+      .catch((error) => {
         if (error.code === 11000) {
-          reject('ALREADY_EXISTS')
+          throw new Error('ALREADY_EXISTS')
         } else {
-          reject()
+          throw error
         }
       })
-    })
   }
 
-  odm.find = (token) => {
-    return new Promise((resolve, reject) => {
-      collection.findOne({token: token}).then((doc) => {
-        if (!doc) {
-          reject('NOT_FOUND')
-        } else {
-          resolve(schema.output(doc))
-        }
-      }).catch(reject)
+  odm.find = (token) => collection
+    .findOne({token: token})
+    .then((doc) => {
+      if (doc) return schema.output(doc)
     })
-  }
 
-  odm.list = () => {
-    return new Promise((resolve, reject) => {
-      collection.find().toArray().then((docs) => {
-        const result = docs.map(schema.output)
-        resolve(result)
-      }).catch(reject)
-    })
-  }
+  odm.list = () => collection
+    .find()
+    .toArray()
+    .then((docs) => docs.map(schema.output))
 
   odm.update = (token, changeset) => {
     changeset.updated = new Date()
-
-    return new Promise((resolve, reject) => {
-      collection.findOneAndUpdate({token: token}, {
+    return collection
+      .findOneAndUpdate({token: token}, {
         $set: schema.input(changeset)
       }, {
         returnOriginal: false
-      }).then((doc) => {
-        if (!doc.value) {
-          reject('NOT_FOUND')
-        } else {
-          resolve(schema.output(doc.value))
-        }
-      }).catch(reject)
-    })
+      })
+      .then((doc) => {
+        if (doc.value) return schema.output(doc.value)
+      })
   }
 
-  odm.delete = (token) => {
-    return new Promise((resolve, reject) => {
-      collection.findOneAndDelete({token: token}).then((doc) => {
-        if (!doc.value) {
-          reject('NOT_FOUND')
-        } else {
-          resolve(schema.output(doc.value))
-        }
-      }).catch(reject)
+  odm.delete = (token) => collection
+    .findOneAndDelete({token: token})
+    .then((doc) => {
+      if (doc.value) return schema.output(doc.value)
     })
-  }
 
   return odm
 }

--- a/test/http/errors_test.js
+++ b/test/http/errors_test.js
@@ -8,19 +8,6 @@ const validate = require('./_validate')
 describe('errors', () => {
   const nonExistentRoute = '/sud8f6g6aqq1u2e'
 
-  it('PUT should not be allowed to be called on the base URI', (done) => {
-    request(server)
-      .put('/')
-      .auth(admin.username, admin.password)
-      .send({'url': 'not_a_valid_url'})
-      .expect(405)
-      .expect('Allow', 'GET, POST')
-      .expect('Content-Type', /json/)
-      .end((_, res) => {
-        validate.error(res.body).then(done)
-      })
-  })
-
   it('GET should return 404 on non existing resource', (done) => {
     request(server)
       .get(nonExistentRoute)


### PR DESCRIPTION
- Removed PUT / because it is a) a lot code for no value and b) looks incomplete (other methods like PATCH/DELETE/…? were also not stubbed/tested; idea: if really needed, maybe use server.any() instead of just server.put()).
- functional approach to error handling (I expect you to prefer `(res) => (err) => {}` over `res => err => {}` but the linter does allow both!?)
- inline promise the odm (more of a suggestion, i would prefer this kind of style...)